### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Multicycle RISC Processor Design
 
-This repository contains the Verilog source code of the design of a multicycle RISC processor. Additional details regarding the ISA, implementation, and verification can be explored in the provided PDF [report](MulticycleRISCProcessor.pdf).
+This repository contains the Verilog source code of the design of a multicycle RISC processor. Additional details regarding the ISA, implementation, and verification can be explored in the provided PDF [report](docs/Report.pdf).
 
 # Table of Contents
 


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file. The change updates the link to the PDF report to point to a new location in the `docs` directory.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the link to the PDF report from `MulticycleRISCProcessor.pdf` to `docs/Report.pdf`.